### PR TITLE
Launch dev tools automatically when debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,10 @@
         },
         "args": [".", "--remote-debugging-port=9223"],
         "outputCapture": "std",
-        "console": "integratedTerminal"
+        "console": "integratedTerminal",
+        "env": {
+          "AXONOPS_DEV_TOOLS": "true"
+        }
       }
     ]
   }


### PR DESCRIPTION
This is to make the VSCode debugger launch Dev Tools automatically. 