### PR TITLE
feat: updating core electron deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "license-checker": "^25.0.1"
       },
       "optionalDependencies": {
-        "electron-installer-debian": "^3.1.0"
+        "electron-installer-debian": "^3.2.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,9 +84,9 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
-        "@electron/rebuild": "^3.6.0",
-        "electron": "^31.6.0",
-        "electron-builder": "^24.13.3",
+        "@electron/rebuild": "^3.7.2",
+        "electron": "^35.1.1",
+        "electron-builder": "^26.0.12",
         "license-checker": "^25.0.1"
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -305,9 +305,9 @@
   },
   "repository": "https://github.com/axonops/axonops-workbench",
   "devDependencies": {
-    "@electron/rebuild": "^3.6.0",
-    "electron": "^31.6.0",
-    "electron-builder": "^24.13.3",
+    "@electron/rebuild": "^3.7.2",
+    "electron": "^35.1.1",
+    "electron-builder": "^26.0.12",
     "license-checker": "^25.0.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "license-checker": "^25.0.1"
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^3.1.0"
+    "electron-installer-debian": "^3.2.0"
   },
   "dependencies": {
     "@ramumb/strip-tags": "^0.1.3",


### PR DESCRIPTION
Updating deps due to fix for this bug on Apple Silcon builds https://github.com/electron-userland/electron-builder/issues/8415

```
      "devDependencies": {
        "@electron/rebuild": "^3.6.0", -> updated to 3.7.2
        "electron": "^31.6.0", -> updated to 35.1.1
        "electron-builder": "^24.13.3", -> updated to 26.0.12
        "license-checker": "^25.0.1"
      }
```

Also updated
```
  "optionalDependencies": {
    "electron-installer-debian": "^3.2.0"
  },
```