### PR TITLE
Changes and updates for the SSH tunneling feature

### DIFF
--- a/custom_node_modules/renderer/clusters.js
+++ b/custom_node_modules/renderer/clusters.js
@@ -188,6 +188,45 @@ let getClusters = async (workspaceID, rawData = false) => {
             sshTunnel = []
           }
 
+          /**
+           * Check if either a passphrase or a private key exist
+           * If so then set them in the OS keychain and remove them
+           */
+          try {
+            if (['passphrase', 'privatekey'].every((attribute) => sshTunnel[attribute] == undefined))
+              throw 0
+
+            let savedSecrets = temp.info.secrets,
+              finalSecrets = {}
+
+            if (savedSecrets != undefined) {
+              finalSecrets = {
+                ...savedSecrets
+              }
+            }
+
+            if (sshTunnel.passphrase != undefined)
+              delete sshTunnel.passphrase
+
+            if (sshTunnel.privatekey != undefined) {
+              finalSecrets.sshPrivatekey = `${sshTunnel.privatekey}`
+
+              delete sshTunnel.privatekey
+            }
+
+            await Keytar.setPassword(
+              'AxonOpsWorkbenchClustersSecrets',
+              temp.info.id, JSON.stringify({
+                ...finalSecrets
+              })
+            )
+
+            await FS.writeFileSync(Path.join(clusterFolderPath, 'config', 'ssh-tunnel.json'), applyJSONBeautify(sshTunnel))
+          } catch (e) {}
+
+          sshTunnel.passphrase = temp.info.secrets.sshPassphrase
+          sshTunnel.privatekey = temp.info.secrets.sshPrivatekey
+
           // Set SSH tunneling info in `temp.ssh` object
           temp.ssh = sshTunnel
         } catch (e) {}
@@ -282,6 +321,22 @@ let saveCluster = async (workspaceID, cluster) => {
 
       // Change what can be changed from SSH tunneling info values to variables
       cluster.ssh = await variablesManipulation(workspaceID, cluster.ssh)
+
+      try {
+        delete cluster.ssh.passphrase
+      } catch (e) {}
+
+      try {
+        if (cluster.ssh.privatekey == undefined)
+          throw 0
+
+        if (cluster.info.secrets == undefined)
+          cluster.info.secrets = {}
+
+        cluster.info.secrets.sshPrivatekey = `${cluster.ssh.privatekey}`
+
+        delete cluster.ssh.privatekey
+      } catch (e) {}
 
       // Write final SSH tunneling info in the `ssh-tunnel.json` file
       await FS.writeFileSync(Path.join(clusterFolderPath, 'config', 'ssh-tunnel.json'), applyJSONBeautify(cluster.ssh))
@@ -425,6 +480,22 @@ let updateCluster = async (workspaceID, cluster) => {
 
       // Change what can be changed from SSH tunneling info values to variables
       cluster.ssh = await variablesManipulation(workspaceID, cluster.ssh)
+
+      try {
+        delete cluster.ssh.passphrase
+      } catch (e) {}
+
+      try {
+        if (cluster.ssh.privatekey == undefined)
+          throw 0
+
+        if (cluster.info.secrets == undefined)
+          cluster.info.secrets = {}
+
+        cluster.info.secrets.sshPrivatekey = `${cluster.ssh.privatekey}`
+
+        delete cluster.ssh.privatekey
+      } catch (e) {}
 
       // Write final SSH tunneling info in the `ssh-tunnel.json` file
       await FS.writeFileSync(Path.join(newClusterFolderPath, 'config', 'ssh-tunnel.json'), applyJSONBeautify(cluster.ssh))


### PR DESCRIPTION
**🛠️ Improvement**
- SSH private key path and its passphrase have been moved to the OS keychain, instead of the `ssh-tunnel.json` info file.
	- For saved connections before that update, the workbench will detect those values, move them to the OS keychain, and remove them from the info file.

**🐛 Fix**
- Private key file name is not cleared from a previous connection editing process when attempting to add a new connection.
- The connection is being marked for passing a test connection successfully when editing its data without testing.
	- Now the connection won't be marked as such without passing a test connection before editing.