### PR TITLE
Improvements and updates for the CLI feature

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -520,7 +520,7 @@ App.on('ready', () => {
          * Send a `shown` status to the main view
          * This will tell the app to load workspaces
          */
-        views.main.webContents.send('windows-shown')
+        setTimeout(() => views.main.webContents.send('windows-shown'))
       }, 100)
     }, 125)
   }

--- a/package.json
+++ b/package.json
@@ -341,6 +341,7 @@
     "chartjs-plugin-zoom": "^2.2.0",
     "cheerio": "^1.1.2",
     "cli-spinner": "^0.2.10",
+    "cli-table3": "^0.6.5",
     "co": "^4.6.0",
     "command-line-usage": "^7.0.3",
     "configparser": "^0.3.10",

--- a/renderer/js/init.js
+++ b/renderer/js/init.js
@@ -1893,11 +1893,24 @@ $(document).on('checkForUpdates', function(e, manualCheck = false) {
 })
 
 // Once the UI is ready, get all workspaces
-$(document).ready(() => IPCRenderer.on('windows-shown', () => {
-  IPCRenderer.send('cli:ready')
+$(document).ready(() => IPCRenderer.on('windows-shown', () => $(document).trigger('getWorkspaces')))
 
-  $(document).trigger('getWorkspaces')
-}))
+$(document).ready(() => {
+  let startTime = new Date().getTime(),
+    checkModulesAreLoaded = () => {
+      setTimeout(() => {
+        try {
+          if (Modules.Workspaces != undefined)
+            IPCRenderer.send('cli:ready')
+        } catch (e) {
+          if (new Date().getTime() - startTime < 5000)
+            checkModulesAreLoaded()
+        }
+      }, 25)
+    }
+
+  checkModulesAreLoaded()
+})
 
 $(document).on('initialize', () => {
   try {


### PR DESCRIPTION
**💎 New**
- The CLI now supports passing a workspace folder path, or a folder containing one or more workspaces, in addition to accepting a JSON string or JSON file path.
	- All workspaces will be imported in one process, alongside all connections inside them.
- A new argument `--json` has been added, when used, the output will be returned as a JSON object or an array of JSON items (as a string).
	- By default, process outputs are formatted as human-readable text. Use --json for machine-friendly, minified JSON.

**🛠️ Improvement/Update**
- Enhanced `--help` output with clearer sections and additional notes.
- Reduced overall process execution time for faster completion.