### PR TITLE
CQL autocomplete improvements, console fixes, and dependency refactoring

### DIFF
--- a/custom_modules/main/consts.js
+++ b/custom_modules/main/consts.js
@@ -55,7 +55,7 @@ const Constants = {
    * From:
    * https://github.com/apache/cassandra/blob/trunk/src/resources/org/apache/cassandra/cql3/reserved_keywords.txt
    */
-  CQLKeywords: ['ADD', 'ALLOW', 'ALTER', 'AND', 'APPLY', 'ASC', 'AUTHORIZE', 'BATCH', 'BEGIN', 'BY', 'COLUMNFAMILY', 'CREATE', 'DELETE', 'DESC', 'DROP', 'ENTRIES', 'EXECUTE', 'FROM', 'FULL', 'GRANT', 'IF', 'IN', 'INDEX', 'INFINITY', 'INSERT', 'INTO', 'IS', 'KEYSPACE', 'LIMIT', 'MATERIALIZED', 'MODIFY', 'NAN', 'NORECURSIVE', 'NOT', 'NULL', 'OF', 'ON', 'OR', 'ORDER', 'PRIMARY', 'RENAME', 'REVOKE', 'SCHEMA', 'SELECT', 'SET', 'TABLE', 'TO', 'TOKEN', 'TRUNCATE', 'UNLOGGED', 'UPDATE', 'USE', 'USING', 'VIEW', 'WHERE', 'WITH', 'FILTERING'],
+  CQLKeywords: ['ADD', 'ALLOW', 'ALTER', 'AND', 'APPLY', 'ASC', 'AUTHORIZE', 'BATCH', 'BEGIN', 'BY', 'COLUMNFAMILY', 'CREATE', 'DELETE', 'DESC', 'DROP', 'ENTRIES', 'EXECUTE', 'FROM', 'FULL', 'GRANT', 'IF', 'IN', 'INDEX', 'INFINITY', 'INSERT', 'INTO', 'IS', 'KEYSPACE', 'LIMIT', 'MATERIALIZED', 'MODIFY', 'NAN', 'NORECURSIVE', 'NOT', 'NULL', 'OF', 'ON', 'OR', 'ORDER', 'PRIMARY', 'RENAME', 'REVOKE', 'SCHEMA', 'SELECT', 'SET', 'TABLE', 'TO', 'TOKEN', 'TRUNCATE', 'UNLOGGED', 'UPDATE', 'USE', 'USING', 'VIEW', 'WHERE', 'WITH', 'FILTERING', 'TRIGGER', 'TYPE'],
   TableDefaultMetadata: {
     '5.0': [{
         name: 'additional_write_policy',
@@ -259,12 +259,12 @@ const Constants = {
       Basic: /^\s*CREATE/i,
       Patterns: [
         /^\s*CREATE(\s+OR\s+REPLACE)?\s+AGGREGATE(\s+IF\s+NOT\s+EXISTS)?\s+(\w+)\S*(?!.)/i,
-        /^\s*CREATE\s+(CUSTOM\s+)?INDEX(\s+IF\s+NOT\s+EXISTS)?\s*(\w+)?\s+ON\s+(\w+)?\S*(?!.)/i,
+        /^\s*CREATE\s+(CUSTOM\s+)?INDEX(\s+IF\s+NOT\s+EXISTS)?\s*(\w+)\s+ON\s+(\w+)?\S*(?!.)/i,
         /^\s*CREATE(\s+OR\s+REPLACE)?\s+FUNCTION(\s+IF\s+NOT\s+EXISTS)?\s+\S*(?!.)/i,
         /^\s*CREATE\s+MATERIALIZED\s+VIEW(\s+IF\s+NOT\s+EXISTS)?\s+\S*(?!.)/i,
         /^\s*CREATE\s+TABLE(\s+IF\s+NOT\s+EXISTS)?\s+(\w+)?\S*(?!.)/i,
         /^\s*CREATE\s+TRIGGER\s+(\w+)\s+ON\s+\S*(?!.)/i,
-        /^\s*CREATE\s+TYPE(\s+IF\s+NOT\s+EXISTS)?\s+\S*(?!.)/i
+        /^\s*CREATE\s+TYPE(\s+IF\s+NOT\s+EXISTS)?\s+\S*(?!.)/i,
       ]
     },
     Delete: {
@@ -327,7 +327,8 @@ const Constants = {
       Basic: /^\s*WHERE/i,
       Patterns: [
         /(?:\bWHERE\s+$)|(?:\b(?:AND|OR)\s+$)/i,
-        /(?:\SET\s+$)|(?:\b(?:,)\s+$)/i
+        /(?:\SET\s+$)|(?:\b(?:,)\s+$)/i,
+        /(?:\ON\s+.+\s+\w*$)/i
       ]
     }
   },

--- a/renderer/js/events/connections/ipc.js
+++ b/renderer/js/events/connections/ipc.js
@@ -1118,7 +1118,11 @@
 
           $('input#ttl').closest('div.row.data-ttl-row').toggle(!(data.isCounterTable == 'true'))
 
+          $('input#insertionTimestamp').closest('div.data-insertion-timestamp-row').toggle(!(data.isCounterTable == 'true'))
+
           $(`div[action="insert-row"] div.types-of-transactions`).toggle(!(data.isCounterTable == 'true'))
+
+          $(`div#extraOptionsBadge`).toggle(!(data.isCounterTable == 'true'))
 
           $('input#insertNoSelectOption').prop('checked', true)
           $('input#insertNoSelectOption').trigger('change')

--- a/renderer/js/funcs.js
+++ b/renderer/js/funcs.js
@@ -2691,13 +2691,14 @@ let buildTreeview = async (metadata, ignoreTitles = false, _workspaceID = '', _c
       throw 0
 
     // Get a random ID for the `Virtual Keyspaces` node
-    let virtualKeyspacesParentID = await getMD5IDForNode()
+    let virtualKeyspacesParentID = await getMD5IDForNode(),
+      virtualKeyspacesCount = metadata.keyspaces.filter((keyspace) => keyspace.virtual).length
 
     // Define the node structure
     let structure = {
       id: virtualKeyspacesParentID,
       parent: keyspacesID,
-      text: `Virtual Keyspaces (<span>${virtualNodes.length}</span>)`,
+      text: `Virtual Keyspaces (<span>${virtualKeyspacesCount}</span>)`,
       type: 'default',
       state: {
         opened: true,

--- a/renderer/js/init.js
+++ b/renderer/js/init.js
@@ -1461,7 +1461,8 @@ $(document).on('initialize', () => {
         // Define the path to all binaries
         let binariesPath = Path.join((extraResourcesPath != null ? Path.join(appPath) : Path.join(__dirname, '..', '..')), 'main', 'bin'),
           // Define binaries to be checked
-          binaries = ['cqlsh', 'keys_generator']
+          // binaries = ['cqlsh', 'keys_generator']
+          binaries = ['cqlsh']
 
         // Check their existence
         Terminal.run(`cd "${binariesPath}" && ${OS.platform() == 'win32' ? 'dir' : 'ls'}`, (err, data, stderr) => {


### PR DESCRIPTION
**💎 New**
- Added support for `CREATE INDEX` and `CREATE CUSTOM INDEX` statements. This includes suggestions for keyspaces, tables, and columns (including multiple columns for custom indexes).

**🛠️ Improvement/Update**
- Executing utility actions (such as enabling query tracing or changing page size) no longer clears or alters the current content of the editor.
- `USING TIMESTAMP` option is now hidden for counter tables.
- Decoupled the workbench from the keys_generator binary. It now relies entirely on the Node.js package.

**🐛 Fix**
- Fixed an issue where tooltips were missing for CQL statement buttons in the enhanced console.
- Fixed a miscalculating of the number of virtual keyspaces.