### PR TITLE
fix: add missing comma before PRIMARY KEY in CQL description output

### DIFF
--- a/custom_modules/renderer/connections.js
+++ b/custom_modules/renderer/connections.js
@@ -1344,7 +1344,16 @@ let getCQLDescription = (connectionID, scope, callback) => {
        * If `null` has been received then we weren't able to get the result
        * Call the `callback` function and pass the final CQL description
        */
-      callback(data.result.data.ddl)
+      let ddl = data.result.data.ddl
+
+      // Workaround for upstream cqlai-node bug: the last column line before
+      // `PRIMARY KEY` is emitted without a trailing comma, producing invalid CQL.
+      try {
+        if (typeof ddl === 'string')
+          ddl = ddl.replace(/([^,\s])(\s*\r?\n\s+PRIMARY KEY\b)/g, '$1,$2')
+      } catch (e) {}
+
+      callback(ddl)
     } catch (e) {
       // If any error has occurred then return the `null` value
       callback(null)


### PR DESCRIPTION
## Summary
- Patches the DDL string returned by `getCQLDescription` so the last column line before `PRIMARY KEY` always has a trailing comma.
- Workaround for an upstream bug in `@axonops/cqlai-node`'s native `GetDDL` output, which currently emits invalid CQL for keyspace/table descriptions.

Fixes #1079.

## Test plan
- [ ] Right-click a keyspace → "Get CQL Description" → display: every `CREATE TABLE` has a comma on the line preceding `PRIMARY KEY`.
- [ ] Right-click a keyspace → "Get CQL Description" → save to file: saved `.cql` file is valid and can be re-run via `SOURCE`.
- [ ] Single-PK and composite-PK tables both render correctly.
- [ ] Tables with collection / UDT / frozen column types ending in `>` still get the comma inserted.

Assisted-by: Claude Code