### PR TITLE
fix(deps): resolve 8 npm audit advisories in dependency overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file was introduced during the 0.9.x series. For changes released before it
+existed, see the [GitHub releases](https://github.com/axonops/axonops-workbench/releases).
+
+## [Unreleased]
+
+### Security
+
+- Resolved all 8 outstanding `npm audit` advisories (6 high, 2 moderate). Most were
+  caused by `overrides` entries in `package.json` that pinned versions below the
+  patched releases, so the overrides themselves were holding vulnerable code in place
+  ([#1088](https://github.com/axonops/axonops-workbench/issues/1088)).
+  - `js-yaml` — quadratic CPU consumption in `!!omap` resolution (GHSA-5p4m-2wfm-xmqj).
+  - `brace-expansion` — denial of service via unbounded expansion (GHSA-mh99-v99m-4gvg,
+    GHSA-rgw5-rvv9-x895).
+  - `undici` — response desynchronization, cross-user information disclosure, CRLF
+    injection and cookie attribute injection (GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272,
+    GHSA-m8rv-5g2x-5cg5, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm).
+  - `dompurify` — cross-site scripting via a detached subtree left executable after
+    `IN_PLACE` hook removal (GHSA-55q2-fjhq-7xh7). This also clears the advisory
+    reported against `monaco-editor`, which bundles it.
+  - `fast-uri` — host confusion via a backslash authority introducer (GHSA-7p8r-x3mc-p8w7).
+  - `browserslist` — unbounded memory growth and a crash via untrusted custom stats
+    (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g).
+  - `electron` — sandboxed iframes could bypass the `allow-popups` restriction through
+    the OpenURL navigation path (GHSA-9f4c-93c8-jc8g).
+
+[Unreleased]: https://github.com/axonops/axonops-workbench/compare/v0.9.3...HEAD

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "jquery": "^3.6.3",
         "jquery-sortablejs": "^1.6.1",
         "jquery.json-viewer": "^1.5.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.2",
         "json-beautify": "^1.1.1",
         "jsonfile": "^6.2.0",
         "jsonrepair": "^3.13.0",
@@ -96,7 +96,7 @@
         "@babel/preset-env": "^7.24.0",
         "@electron/rebuild": "^4.0.4",
         "babel-jest": "^29.7.0",
-        "electron": "^41.7.1",
+        "electron": "^41.10.3",
         "electron-builder": "^26.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
@@ -1937,9 +1937,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2023,6 +2023,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@electron/notarize": {
@@ -2146,6 +2157,16 @@
         "node": ">=16.4"
       }
     },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2255,9 +2276,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2312,9 +2333,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2384,30 +2405,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -4768,9 +4765,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4854,16 +4851,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -4878,9 +4865,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -4898,11 +4885,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5128,9 +5115,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -5254,6 +5241,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/chownr": {
@@ -5891,9 +5887,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6023,9 +6019,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6147,9 +6143,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.2.tgz",
-      "integrity": "sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==",
+      "version": "41.10.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.7.tgz",
+      "integrity": "sha512-AqIiefddlf5i+HYCGatr8VlBuEbWJpad4/yloBFYcMB2r57j7xhW1ogiJ+BfA5kxQyfmSs5yjwy54Me+wJn1jw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6299,9 +6295,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6691,9 +6687,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6965,9 +6961,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -7028,6 +7024,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -7168,9 +7174,9 @@
       }
     },
     "node_modules/front-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7351,29 +7357,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7385,6 +7368,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/global-agent": {
@@ -8896,9 +8897,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -9638,9 +9639,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9895,6 +9896,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
@@ -9924,9 +9934,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11934,9 +11944,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12229,15 +12239,6 @@
         "node": ">=12.17"
       }
     },
-    "node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -12362,9 +12363,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@babel/preset-env": "^7.24.0",
     "@electron/rebuild": "^4.0.4",
     "babel-jest": "^29.7.0",
-    "electron": "^41.7.1",
+    "electron": "^41.10.3",
     "electron-builder": "^26.7.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
@@ -288,7 +288,7 @@
     "jquery": "^3.6.3",
     "jquery-sortablejs": "^1.6.1",
     "jquery.json-viewer": "^1.5.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.2",
     "json-beautify": "^1.1.1",
     "jsonfile": "^6.2.0",
     "jsonrepair": "^3.13.0",
@@ -329,12 +329,14 @@
     "zxcvbn": "^4.4.2"
   },
   "overrides": {
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.9",
     "tar": "^7.5.19",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.14",
     "form-data": "^4.0.6",
     "ip-address": "^10.1.1",
-    "undici": "^8.5.0",
+    "fast-uri": "^3.1.5",
+    "browserslist": "^4.28.8",
+    "undici": "^8.10.1",
     "@electron/rebuild": {
       "undici": "^6.27.0",
       "node-gyp": {
@@ -342,55 +344,55 @@
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^3.15.0"
+      "js-yaml": "^4.3.2"
     },
     "front-matter": {
-      "js-yaml": "^3.15.0"
+      "js-yaml": "^3.15.2"
     },
     "@electron/asar": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "@eslint/eslintrc": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "@humanwhocodes/config-array": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "@jest/reporters": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "dir-compare": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "eslint": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "jest-config": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "jest-runtime": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "read-package-json": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "rimraf": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "temp": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "test-exclude": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     },
     "@electron/universal": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.4"
     },
     "filelist": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.4"
     },
     "node-gyp": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.4"
     }
   }
 }


### PR DESCRIPTION
Closes #1088

## What

Resolves all 8 outstanding `npm audit` advisories (6 high, 2 moderate).

Most of these were not upstream releases we had fallen behind on. The `overrides` block in `package.json` pinned versions *below* the patched releases, so the overrides themselves were holding vulnerable code in place. Sixteen of the twenty-two edits here are override bumps.

| Package | Change | Advisories |
|---|---|---|
| `js-yaml` (direct) | `^4.1.0` → `^4.3.2` | GHSA-5p4m-2wfm-xmqj |
| `brace-expansion` (16 override entries) | `^5.0.7`→`^5.0.9`, `^1.1.16`→`^1.1.18`, `^2.1.2`→`^2.1.4` | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| `undici` | `^8.5.0` → `^8.10.1` | GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272, GHSA-m8rv-5g2x-5cg5, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm |
| `dompurify` | `^3.4.11` → `^3.4.14` | GHSA-55q2-fjhq-7xh7 |
| `fast-uri` | new override `^3.1.5` | GHSA-7p8r-x3mc-p8w7 |
| `browserslist` | new override `^4.28.8` | GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g |
| `electron` | `^41.7.1` → `^41.10.3` | GHSA-9f4c-93c8-jc8g |

Two notes on the table:

- The `dompurify` bump also clears the advisory reported against `monaco-editor`, which bundles it. npm's suggested remedy there was a semver-major *downgrade* to `monaco-editor@0.53.0`; that is not what this PR does.
- `electron` lives in `devDependencies` but ships the application runtime, so the sandbox-bypass advisory is a shipped-product issue. The declared range already permitted 41.10.3 — only the lockfile was stale.

## The js-yaml overrides are deliberately asymmetric

This is the part worth reviewing carefully.

`front-matter` is pinned to **js-yaml `^3.15.2`**, not 4.x. `front-matter@4.0.2` calls `parser.safeLoad`, which js-yaml 4 removed:

```
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```

`front-matter` is used by `custom_modules/renderer/snippets.js` at six call sites (via `renderer/js/libs.js:113`), all with default options — so moving it to 4.x throws on every snippet parse. There is no newer `front-matter`; 4.0.2 is latest and still declares `js-yaml ^3.13.1`. `gray-matter` and `yaml-front-matter` are also pinned to js-yaml 3.x.

js-yaml **3.15.2 is patched** — the advisory range is `3.0.0 - 3.15.0`. The previous `^3.15.0` override was only resolving to vulnerable code because the lockfile entry was stale. Pinning `^3.15.2` explicitly prevents that recurring.

`@istanbuljs/load-nyc-config` **does** move to `^4.3.2`: it calls `require('js-yaml').load()` directly (`index.js:80`), which is valid in 4.x, and it is coverage-tooling only.

## CHANGELOG

The repo had no `CHANGELOG.md`. This PR adds one, seeded at the current 0.9.x series and pointing at GitHub releases for prior history, per the org standard (Keep a Changelog 1.1.0 + SemVer).

## Verification

- `npm audit` — **0 vulnerabilities**, from 8. Confirmed against a clean `node_modules` reinstall from the committed lockfile, so this is a fresh resolve rather than an incremental one.
- `npm test` — 250 passed, 11 skipped, 0 failed.
- `npm run lint` — 4099 problems (3759 errors, 340 warnings), **identical to the `main` baseline**. All pre-existing; unchanged by this PR.
- `npm run mac:arm64:dev` — build succeeds; DMG, PKG and ZIP produced. Packaged app launches and stays running with a clean log.
- Verified inside the shipped `app.asar`: `front-matter` → js-yaml 3.15.2, top-level js-yaml → 4.3.2.

## Not covered

- The snippets feature was verified as `front-matter` parsing correctly in isolation plus the correct js-yaml shipping in the asar — **not** exercised through the running UI. Worth a reviewer clicking through snippet load/save.
- The app launch was a liveness check, not a functional smoke test.
- Only the macOS arm64 target was built. Windows and Linux builds are unverified.

## Out of scope

Dependabot reports 12 alerts on `main` against this PR's 8. The difference is counting, not coverage — Dependabot files `undici` as 5 separate alerts and `js-yaml` as 2. All 11 npm alerts are fixed here.

The 12th is `setuptools < 83.0.0` in `requirements.txt`, a Python build-tooling dependency outside `package.json`. Tracked separately in #1089.

Stale-but-not-vulnerable majors were deliberately left alone to keep this reviewable: axios, marked, i18next, jquery, uuid, eslint, `@babel/*`, jest, better-sqlite3, diff, dotenv, open, yargs, tinykeys, node-rsa, `@xterm/xterm`.

Assisted-by: Claude Code
